### PR TITLE
[ccassandra/extract.js] Try fix from tardypad#89

### DIFF
--- a/plugins/ccassandra/extract.js
+++ b/plugins/ccassandra/extract.js
@@ -1,5 +1,15 @@
 function(page) {
-    var regex = /&lt;img[^&]*src="([^"]*media.tumblr.com\/[^"]*)"/;
+    var regex = /<a\sclass="ga-tracking\sjs-episode\s+"(.|\s)+?href="([^"]+)"/
     var match = regex.exec(page);
-    return match[1].replace("_500","_1280");
+    var url = "https://tapas.io" + match[2]
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", url , false);
+    xhr.send(null);
+    if(xhr.status === 200)
+    {
+        var newPage = xhr.responseText;
+        var regex2 = /<img\s*src="([^"]*)"\sclass="content__img"/
+        var match2 = regex2.exec(newPage);
+        return match2[1];
+    }
 }


### PR DESCRIPTION
Even though this fix was originally dismissed as not elegant, it is far better than a broken CCassandra plugin!  In general, I disagree with the notion that not everything reasonably feasible with JavaScript is allowed.  For details, see https://github.com/tardypad/sailfishos-daily-comics/issues/89

Furthermore this scheme seems to be generically applicable to comic strips from `tapas.io`.