### PR TITLE
Rectify retrieval of extant Helsingin Sanomat strips …

### DIFF
--- a/plugins/anonyymitelaimet/extract.js
+++ b/plugins/anonyymitelaimet/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<img[^>]*srcset="(\/\/hs.mediadelivery.fi\/img\/[^ ]*) /;
+    var regex = /<img[^>]+srcset="(\/\/[^ "]+)/;
     var match = regex.exec(page);
-    return match[1];
+    return "https:" + match[1];
 }

--- a/plugins/anonyymitelaimet/info.json
+++ b/plugins/anonyymitelaimet/info.json
@@ -5,6 +5,6 @@
   "authors": [
     "Joonas Lehtimäki"
   ],
-  "homepage": "http://anonyymitelaimet.com",
-  "stripSource": "http://www.hs.fi/nyt/anonyymitelaimet/"
+  "homepage": "https://www.hs.fi/nyt/anonyymitelaimet/",
+  "stripSource": "https://www.hs.fi/nyt/anonyymitelaimet/"
 }

--- a/plugins/fingerpori/extract.js
+++ b/plugins/fingerpori/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<img[^>]*srcset="(\/\/hs.mediadelivery.fi\/img\/[^ ]*) /;
+    var regex = /<img[^>]+srcset="(\/\/[^ "]+)/;
     var match = regex.exec(page);
-    return match[1];
+    return "https:" + match[1];
 }

--- a/plugins/fokit/extract.js
+++ b/plugins/fokit/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<img[^>]*srcset="(\/\/hs.mediadelivery.fi\/img\/[^ ]*) /;
+    var regex = /<img[^>]+srcset="(\/\/[^ "]+)/;
     var match = regex.exec(page);
-    return match[1];
+    return "https:" + match[1];
 }

--- a/plugins/fokit/info.json
+++ b/plugins/fokit/info.json
@@ -6,5 +6,5 @@
     "Joonas Rinta-Kanto"
   ],
   "homepage": "https://fokit.wordpress.com/",
-  "stripSource": "http://www.hs.fi/nyt/fokit/"
+  "stripSource": "https://www.hs.fi/sarjakuvat/fokit/"
 }

--- a/plugins/jaatavaspede/extract.js
+++ b/plugins/jaatavaspede/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<img[^>]*srcset="(\/\/hs.mediadelivery.fi\/img\/[^ ]*) /;
-    var match1 = regex.exec(page);
-    return match1[1];
+    var regex = /<img[^>]+srcset="(\/\/[^ "]+)/;
+    var match = regex.exec(page);
+    return "https:" + match[1];
 }

--- a/plugins/jaatavaspede/info.json
+++ b/plugins/jaatavaspede/info.json
@@ -5,6 +5,6 @@
   "authors": [
     "Pertti Jarla"
   ],
-  "homepage": "http://www.hs.fi/jaatavaspede/",
-  "stripSource": "http://www.hs.fi/jaatavaspede/"
+  "homepage": "https://www.hs.fi/jaatavaspede/",
+  "stripSource": "https://www.hs.fi/jaatavaspede/"
 }

--- a/plugins/viivijawagner/extract.js
+++ b/plugins/viivijawagner/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<img[^>]*srcset="(\/\/hs.mediadelivery.fi\/img\/[^ ]*) /;
+    var regex = /<img[^>]+srcset="(\/\/[^ "]+)/;
     var match = regex.exec(page);
-    return match[1];
+    return "https:" + match[1];
 }

--- a/plugins/viivijawagner/info.json
+++ b/plugins/viivijawagner/info.json
@@ -5,6 +5,6 @@
   "authors": [
     "Jussi \"Juba\" Tuomola"
   ],
-  "homepage": "http://www.viivijawagner.net/",
+  "homepage": "https://viivijawagner.com/",
   "stripSource": "https://www.hs.fi/viivijawagner/"
 }


### PR DESCRIPTION
… (https://www.hs.fi/sarjakuvat/), also checked and corrected their metadata.  Also rectify retrieval for "Anonyymit Eläimet" (anonyymitelaimet) and "Jäätävä Spede" (jaatavaspede) even though these strips have finished.

This PR addresses 2/3 of issue #103 and supersedes PR #104.