### PR TITLE
Fix strips hosted at GoComics

### DIFF
--- a/plugins/andycapp/extract.js
+++ b/plugins/andycapp/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/bloomcounty/extract.js
+++ b/plugins/bloomcounty/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/bloomcounty/info.json
+++ b/plugins/bloomcounty/info.json
@@ -5,6 +5,6 @@
   "authors": [
     "Berkeley Breathed"
   ],
-  "homepage": "https://www.berkeleybreathed.com/",
+  "homepage": "http://www.berkeleybreathed.com/",
   "stripSource": "https://www.gocomics.com/bloomcounty"
 }

--- a/plugins/calvinandhobbes/extract.js
+++ b/plugins/calvinandhobbes/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/calvinandhobbes/info.json
+++ b/plugins/calvinandhobbes/info.json
@@ -6,5 +6,5 @@
     "Bill Watterson"
   ],
   "homepage": "https://calvinandhobbes.com/",
-  "stripSource": "https://www.gocomics.com/calvinandhobbes/"
+  "stripSource": "https://www.gocomics.com/calvinandhobbes"
 }

--- a/plugins/cheerupemokid/extract.js
+++ b/plugins/cheerupemokid/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<img[^>]*src="(https://assets.amuniversal.com/[^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/culdesac/extract.js
+++ b/plugins/culdesac/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/fminus/extract.js
+++ b/plugins/fminus/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/fminus/info.json
+++ b/plugins/fminus/info.json
@@ -6,5 +6,5 @@
     "Tony Carrillo"
   ],
   "homepage": "http://www.fminus.net/",
-  "stripSource": "http://www.gocomics.com/fminus"
+  "stripSource": "https://www.gocomics.com/fminus"
 }

--- a/plugins/fowllanguage/extract.js
+++ b/plugins/fowllanguage/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<img[^>]+src="(https:\/\/assets.amuniversal.com\/[0-9a-f]+)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/foxtrot/extract.js
+++ b/plugins/foxtrot/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/foxtrot/info.json
+++ b/plugins/foxtrot/info.json
@@ -6,5 +6,5 @@
     "Bill Amend"
   ],
   "homepage": "http://www.foxtrot.com",
-  "stripSource": "http://www.gocomics.com/foxtrot"
+  "stripSource": "https://www.gocomics.com/foxtrot"
 }

--- a/plugins/fredbasset/extract.js
+++ b/plugins/fredbasset/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/fredbasset/info.json
+++ b/plugins/fredbasset/info.json
@@ -6,6 +6,6 @@
     "Alex Graham",
     "Michael Martin"
   ],
-  "homepage": "http://www.gocomics.com/fredbasset/",
-  "stripSource": "http://www.gocomics.com/fredbasset/"
+  "homepage": "https://www.gocomics.com/fredbasset",
+  "stripSource": "https://www.gocomics.com/fredbasset"
 }

--- a/plugins/garfield/extract.js
+++ b/plugins/garfield/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/garfield/info.json
+++ b/plugins/garfield/info.json
@@ -6,5 +6,5 @@
     "Jim Davis"
   ],
   "homepage": "http://garfield.com/",
-  "stripSource": "http://www.gocomics.com/garfield"
+  "stripSource": "https://www.gocomics.com/garfield"
 }

--- a/plugins/peanuts/extract.js
+++ b/plugins/peanuts/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/peanuts/info.json
+++ b/plugins/peanuts/info.json
@@ -6,5 +6,5 @@
     "Charles Monroe Schulz"
   ],
   "homepage": "http://www.peanuts.com/",
-  "stripSource": "http://www.gocomics.com/peanuts/"
+  "stripSource": "https://www.gocomics.com/peanuts"
 }

--- a/plugins/pearlsbeforeswine/extract.js
+++ b/plugins/pearlsbeforeswine/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/pearlsbeforeswine/info.json
+++ b/plugins/pearlsbeforeswine/info.json
@@ -5,6 +5,6 @@
   "authors": [
     "Stephan Pastis"
   ],
-  "homepage": "http://www.gocomics.com/pearlsbeforeswine",
-  "stripSource": "http://www.gocomics.com/pearlsbeforeswine"
+  "homepage": "https://www.gocomics.com/pearlsbeforeswine",
+  "stripSource": "https://www.gocomics.com/pearlsbeforeswine"
 }

--- a/plugins/theboondocks/extract.js
+++ b/plugins/theboondocks/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/theboondocks/info.json
+++ b/plugins/theboondocks/info.json
@@ -5,6 +5,6 @@
   "authors": [
     "Aaron McGruder"
   ],
-  "homepage": "http://www.gocomics.com/boondocks",
-  "stripSource": "http://www.gocomics.com/boondocks"
+  "homepage": "https://www.gocomics.com/boondocks",
+  "stripSource": "https://www.gocomics.com/boondocks"
 }

--- a/plugins/wizardofid/extract.js
+++ b/plugins/wizardofid/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<picture class="[^"]*cropped-strip[^<]*<img[^>]* src="([^"]*)"/;
+    var regex = /imageSrcSet="(http[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/wizardofid/info.json
+++ b/plugins/wizardofid/info.json
@@ -6,6 +6,6 @@
     "Brant Parker",
     "Johnny Hart"
   ],
-  "homepage": "http://www.gocomics.com/wizardofid",
-  "stripSource": "http://www.gocomics.com/wizardofid"
+  "homepage": "https://www.gocomics.com/wizardofid",
+  "stripSource": "https://www.gocomics.com/wizardofid"
 }


### PR DESCRIPTION
Several strips on https://www.gocomics.com stopped working recently. This patch updates the strips.

1. always use https without trailing slash
2. new extract regexp

Fixes issues #115, #118, #119, #121, #122 and addresses most of issue #123 (except for the strips added by PR #111).