### PR TITLE
fix all gocomics titles

### DIFF
--- a/plugins/andycapp/extract.js
+++ b/plugins/andycapp/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/backtobc/extract.js
+++ b/plugins/backtobc/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/bloomcounty/extract.js
+++ b/plugins/bloomcounty/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/calvinandhobbes/extract.js
+++ b/plugins/calvinandhobbes/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/cheerupemokid/extract.js
+++ b/plugins/cheerupemokid/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/culdesac/extract.js
+++ b/plugins/culdesac/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/fminus/extract.js
+++ b/plugins/fminus/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/fowllanguage/extract.js
+++ b/plugins/fowllanguage/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/foxtrot/extract.js
+++ b/plugins/foxtrot/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/fredbasset/extract.js
+++ b/plugins/fredbasset/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/garfield/extract.js
+++ b/plugins/garfield/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/peanuts/extract.js
+++ b/plugins/peanuts/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/pearlsbeforeswine/extract.js
+++ b/plugins/pearlsbeforeswine/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/theboondocks/extract.js
+++ b/plugins/theboondocks/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/wizardofid/extract.js
+++ b/plugins/wizardofid/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /imageSrcSet="(http[^" ?]+)/;
+    var regex = /"url":"(https:\/\/featureassets.gocomics.com\/[^" ?]+)/;
     var match = regex.exec(page);
     return match[1];
 }


### PR DESCRIPTION
New extract.js pattern for all gocomics titles:
- andycapp
- backtobc
- bloomcounty
- calvinandhobbes
- cheerupemokid
- culdesac
- fminus
- fowllanguage
- foxtrot
- fredbasset
- garfield
- peanuts
- pearlsbeforeswine
- theboondocks
- wizardofid