### PR TITLE
Revert "[plugins/update.json] Patch `buni`, adhering to PR #162"

### DIFF
--- a/plugins/update.json
+++ b/plugins/update.json
@@ -1,9 +1,0 @@
-{
-  "plugins": [
-    {
-      "id":"buni",
-      "stripSource":"https://www.bunicomic.com/",
-      "extractJson":"function(page) {var regex = \/<div\s+id=\"comic\">\s+<img\s+src=\"([^? \"]+)\/; var match = regex.exec(page); return match[1];}"
-    }
-  ]
-}


### PR DESCRIPTION
Reverts sailfishos-applications/daily-comics#164, because it was not working; for details see issue #168.