### PR TITLE
[plugins/fokkeensukke/extract.js] Fix RegEx

### DIFF
--- a/plugins/fokkeensukke/extract.js
+++ b/plugins/fokkeensukke/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /\s+src="([^"]+\/images.nrc.nl\/[^"]+)"/;
+    var regex = /<source[^>]+srcset="\s*(\S+)/;
     var match = regex.exec(page);
     return match[1];
 }


### PR DESCRIPTION
But for some reason this yields the first image on **[`https://www.nrc.nl/rubriek/fokke-sukke`](https://www.nrc.nl/rubriek/fokke-sukke)** while this shows the intended image:
`xdg-open "$(curl -LsS https://www.nrc.nl/fokke-sukke | grep -Eo '<source[^>]+srcset="[[:space:]]*[^[:space:]]+' | grep -Eo '[^[:space:]]+$')"`
I am confused, but will merge it, as this PR at least makes it work!