### PR TITLE
[plugins/fokkeensukke/*] Return to old URL & RegEx

### DIFF
--- a/plugins/fokkeensukke/extract.js
+++ b/plugins/fokkeensukke/extract.js
@@ -1,5 +1,5 @@
 function(page) {
-    var regex = /<source[^>]+srcset="\s*(\S+)/;
+    var regex = /\ssrc="([^"]+\/images.nrc.nl\/[^"\s]+)/;
     var match = regex.exec(page);
     return match[1];
 }

--- a/plugins/fokkeensukke/info.json
+++ b/plugins/fokkeensukke/info.json
@@ -8,5 +8,5 @@
     "Bastiaan Geleijnse"
   ],
   "homepage": "https://foksuk.nl",
-  "stripSource": "https://www.nrc.nl/fokke-sukke"
+  "stripSource": "https://www.nrc.nl/rubriek/fokke-sukke/"
 }


### PR DESCRIPTION
Supersedes PR #199, which used the equivalent of:
`xdg-open "$(curl -LsS https://www.nrc.nl/fokke-sukke | grep -Eo '<source[^>]+srcset="[[:space:]]*[^[:space:]]+' | grep -Eo '[^[:space:]]+$')"`
Now reverting to:
`xdg-open "$(curl -Ls https://www.nrc.nl/rubriek/fokke-sukke | grep -Eom 1 '[^[:space:]]src="[^"]+/images.nrc.nl/[^"[:space]]+' | grep -Eo 'http.*$')"`