### PR TITLE
Make Helsingin Sanomat strips work again

### DIFF
--- a/plugins/fingerpori/extract.js
+++ b/plugins/fingerpori/extract.js
@@ -1,5 +1,7 @@
 function(page) {
-    var regex = /<img[^>]+srcset="(\/\/[^ "]+)/;
+    // Thanks to Matti K. for giving me pointers to the api interface!
+    var regex = /"url":\s*"([^"]+)/;
     var match = regex.exec(page);
-    return "https:" + match[1];
+    var url = match[1];
+    return url.replace("WIDTH.EXT","1920.jpg");
 }

--- a/plugins/fingerpori/info.json
+++ b/plugins/fingerpori/info.json
@@ -6,5 +6,7 @@
     "Pertti Jarla"
   ],
   "homepage": "http://fingerpori.org",
-  "stripSource": "https://www.hs.fi/fingerpori/"
+    // To find the API url go: https://www.hs.fi/sarjakuvat/fingerpori/
+    // web developer tools, network / all, search for laneitems, copy url
+  "stripSource": "https://www.hs.fi/api/laneitems/39221/list/normal/290"
 }

--- a/plugins/haraldhirmuinen/extract.js
+++ b/plugins/haraldhirmuinen/extract.js
@@ -1,5 +1,7 @@
 function(page) {
-    var regex = /<img[^>]+srcset="(\/\/[^ "]+)/;
+    // Thanks to Matti K. for giving me pointers to the api interface!
+    var regex = /"url":\s*"([^"]+)/;
     var match = regex.exec(page);
-    return "https:" + match[1];
+    var url = match[1];
+    return url.replace("WIDTH.EXT","1920.jpg");
 }

--- a/plugins/haraldhirmuinen/info.json
+++ b/plugins/haraldhirmuinen/info.json
@@ -8,5 +8,7 @@
       "Chris Browne"
   ],
   "homepage": "https://www.hs.fi/haraldhirmuinen/",
-  "stripSource": "https://www.hs.fi/haraldhirmuinen/"
+    // To find the API url go: https://www.hs.fi/sarjakuvat/haraldhirmuinen/
+    // web developer tools, network / all, search for laneitems, copy url
+  "stripSource": "https://www.hs.fi/api/laneitems/39221/list/normal/298"
 }

--- a/plugins/keskenkasvuisia/extract.js
+++ b/plugins/keskenkasvuisia/extract.js
@@ -1,5 +1,7 @@
 function(page) {
-    var regex = /<img[^>]+srcset="(\/\/[^ "]+)/;
+    // Thanks to Matti K. for giving me pointers to the api interface!
+    var regex = /"url":\s*"([^"]+)/;
     var match = regex.exec(page);
-    return "https:" + match[1];
+    var url = match[1];
+    return url.replace("WIDTH.EXT","1920.jpg");
 }

--- a/plugins/keskenkasvuisia/info.json
+++ b/plugins/keskenkasvuisia/info.json
@@ -7,5 +7,7 @@
       "Jyrki Vainio"
   ],
   "homepage": "https://www.hs.fi/sarjakuvat/keskenkasvuisia/",
-  "stripSource": "https://www.hs.fi/sarjakuvat/keskenkasvuisia/"
+    // To find the API url go: https://www.hs.fi/sarjakuvat/keskenkasvuisia/
+    // web developer tools, network / all, search for laneitems, copy url
+  "stripSource": "https://www.hs.fi/api/laneitems/39221/list/normal/2462"
 }

--- a/plugins/lassijaleevi/extract.js
+++ b/plugins/lassijaleevi/extract.js
@@ -1,5 +1,7 @@
 function(page) {
-    var regex = /<img[^>]+srcset="(\/\/[^ "]+)/;
+    // Thanks to Matti K. for giving me pointers to the api interface!
+    var regex = /"url":\s*"([^"]+)/;
     var match = regex.exec(page);
-    return "https:" + match[1];
+    var url = match[1];
+    return url.replace("WIDTH.EXT","1920.jpg");
 }

--- a/plugins/lassijaleevi/info.json
+++ b/plugins/lassijaleevi/info.json
@@ -5,6 +5,6 @@
   "authors": [
     "Bill Watterson"
   ],
-  "homepage": "https://fi.wikipedia.org/wiki/Lassi_ja_Leevi",
-  "stripSource": "https://www.hs.fi/lassijaleevi/"
+  "homepage": "http://www.calvinandhobbes.com/",
+  "stripSource": "https://www.hs.fi/api/laneitems/39221/list/normal/299"
 }

--- a/plugins/viivijawagner/extract.js
+++ b/plugins/viivijawagner/extract.js
@@ -1,5 +1,7 @@
 function(page) {
-    var regex = /<img[^>]+srcset="(\/\/[^ "]+)/;
+    // Thanks to Matti K. for giving me pointers to the api interface!
+    var regex = /"url":\s*"([^"]+)/;
     var match = regex.exec(page);
-    return "https:" + match[1];
+    var url = match[1];
+    return url.replace("WIDTH.EXT","1920.jpg");
 }

--- a/plugins/viivijawagner/info.json
+++ b/plugins/viivijawagner/info.json
@@ -6,5 +6,7 @@
     "Jussi \"Juba\" Tuomola"
   ],
   "homepage": "https://viivijawagner.com/",
-  "stripSource": "https://www.hs.fi/viivijawagner/"
+    // To find the API url go: https://www.hs.fi/sarjakuvat/viivijawagner/
+    // web developer tools, network / all, search for laneitems, copy url
+  "stripSource": "https://www.hs.fi/api/laneitems/39221/list/normal/291"
 }


### PR DESCRIPTION
This makes the Helsingin Sanomat strip retrieval use the same API that their own pages do.